### PR TITLE
Guard emojiData.custom from raising when read-only

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -96,7 +96,9 @@ function getData(emoji, skin, set, data) {
 
   if (!Object.keys(emojiData).length) {
     emojiData = emoji
-    emojiData.custom = true
+    if (!emojiData.custom) {
+      emojiData.custom = true
+    }
 
     if (!emojiData.search) {
       emojiData.search = buildSearch(emoji)


### PR DESCRIPTION
There's a rare case with custom emojis where `emojiData.custom` will become read-only and throws an error. From what I've tested, this only occurs when it's already set to ``true``, so this fix should potentially prevent this from erroring, at least it has on my end.